### PR TITLE
Feat/moveioc

### DIFF
--- a/StarWars.Lib/MoveCommandIoC.cs
+++ b/StarWars.Lib/MoveCommandIoC.cs
@@ -1,0 +1,21 @@
+using Hwdtech;
+namespace StarWars.Lib;
+
+public class RegisterIoCDependencyMoveCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>("IoC.Register", "Adapters.IMoving", 
+            (Func<object, IMoving>)(obj =>
+            {
+                return (IMoving)obj;
+            }));
+
+        IoC.Resolve<ICommand>("IoC.Register", "Commands.Move", 
+            (Func<object, object>)(obj =>
+            {
+                return new MoveCommand(IoC.Resolve<IMoving>("Adapters.IMoving", obj));
+            }));
+
+    }
+}

--- a/StarWars.Lib/MoveCommandIoC.cs
+++ b/StarWars.Lib/MoveCommandIoC.cs
@@ -1,21 +1,12 @@
 using Hwdtech;
 namespace StarWars.Lib;
 
-public class RegisterIoCDependencyMoveCommand : ICommand
+public class RegisterIoCDependencyMoveCommand : Hwdtech.ICommand
 {
     public void Execute()
     {
-        IoC.Resolve<ICommand>("IoC.Register", "Adapters.IMoving", 
-            (Func<object, IMoving>)(obj =>
-            {
-                return (IMoving)obj;
-            }));
-
-        IoC.Resolve<ICommand>("IoC.Register", "Commands.Move", 
-            (Func<object, object>)(obj =>
-            {
-                return new MoveCommand(IoC.Resolve<IMoving>("Adapters.IMoving", obj));
-            }));
-
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.Move",
+            (Func<object, object>)(obj => 
+            new MoveCommand(IoC.Resolve<IMoving>("Adapters.IMoving", obj)))).Execute();
     }
 }

--- a/StarWars.Lib/MoveCommandIoC.cs
+++ b/StarWars.Lib/MoveCommandIoC.cs
@@ -1,4 +1,4 @@
-using Hwdtech;
+﻿using Hwdtech;
 namespace StarWars.Lib;
 
 public class RegisterIoCDependencyMoveCommand : Hwdtech.ICommand
@@ -6,7 +6,7 @@ public class RegisterIoCDependencyMoveCommand : Hwdtech.ICommand
     public void Execute()
     {
         IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.Move",
-            (Func<object, object>)(obj => 
+            (Func<object, object>)(obj =>
             new MoveCommand(IoC.Resolve<IMoving>("Adapters.IMoving", obj)))).Execute();
     }
 }

--- a/StarWars.Tests/MoveCommandIoCTests.cs
+++ b/StarWars.Tests/MoveCommandIoCTests.cs
@@ -1,0 +1,29 @@
+using Moq;
+using Hwdtech;
+using StarWars.Lib;
+
+public class MoveCommandIoCTests
+{
+    public MoveCommandIoCTests()
+    {
+        var reg = new RegisterIoCDependencyMoveCommand();
+        reg.Execute();
+    }
+
+   [Fact]
+    public void MoveCommand_ShouldUpdatePositionBasedOnVelocity()
+    {
+        var mockObject = new Mock<IMoving>();
+        var initialPosition = new CustomVector(0, 0);
+        var velocity = new CustomVector(1, 1);
+
+        mockObject.SetupProperty(m => m.Position, initialPosition);
+        mockObject.Setup(m => m.Velocity).Returns(velocity);
+
+        var command = (StarWars.Lib.ICommand)IoC.Resolve<StarWars.Lib.ICommand>("Commands.Move", mockObject.Object);
+
+        command.Execute();
+
+        Assert.Equal(new CustomVector(1, 1), mockObject.Object.Position);
+    }
+}

--- a/StarWars.Tests/MoveCommandIoCTests.cs
+++ b/StarWars.Tests/MoveCommandIoCTests.cs
@@ -1,29 +1,31 @@
 using Moq;
 using Hwdtech;
+using Hwdtech.Ioc;
 using StarWars.Lib;
 
 public class MoveCommandIoCTests
 {
     public MoveCommandIoCTests()
     {
-        var reg = new RegisterIoCDependencyMoveCommand();
-        reg.Execute();
+        new InitScopeBasedIoCImplementationCommand().Execute();
     }
 
-   [Fact]
-    public void MoveCommand_ShouldUpdatePositionBasedOnVelocity()
+    [Fact]
+    public void Execute_ShouldRegisterMoveCommandDependency()
     {
-        var mockObject = new Mock<IMoving>();
-        var initialPosition = new CustomVector(0, 0);
-        var velocity = new CustomVector(1, 1);
+        var mockMoving = new Mock<IMoving>();
+        var mockGameObject = new Mock<IDictionary<string, object>>();
 
-        mockObject.SetupProperty(m => m.Position, initialPosition);
-        mockObject.Setup(m => m.Velocity).Returns(velocity);
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Adapters.IMoving",
+            (Func<object, IMoving>)(obj =>
+            {
+                return mockMoving.Object;
+            })).Execute();
 
-        var command = (StarWars.Lib.ICommand)IoC.Resolve<StarWars.Lib.ICommand>("Commands.Move", mockObject.Object);
+        new RegisterIoCDependencyMoveCommand().Execute();
 
-        command.Execute();
-
-        Assert.Equal(new CustomVector(1, 1), mockObject.Object.Position);
+        var moveCommand = IoC.Resolve<StarWars.Lib.ICommand>("Commands.Move", mockGameObject.Object); 
+        Assert.NotNull(moveCommand);
+        Assert.IsType<MoveCommand>(moveCommand);
     }
 }

--- a/StarWars.Tests/MoveCommandIoCTests.cs
+++ b/StarWars.Tests/MoveCommandIoCTests.cs
@@ -1,6 +1,6 @@
-using Moq;
-using Hwdtech;
+﻿using Hwdtech;
 using Hwdtech.Ioc;
+using Moq;
 using StarWars.Lib;
 
 public class MoveCommandIoCTests
@@ -24,7 +24,7 @@ public class MoveCommandIoCTests
 
         new RegisterIoCDependencyMoveCommand().Execute();
 
-        var moveCommand = IoC.Resolve<StarWars.Lib.ICommand>("Commands.Move", mockGameObject.Object); 
+        var moveCommand = IoC.Resolve<StarWars.Lib.ICommand>("Commands.Move", mockGameObject.Object);
         Assert.NotNull(moveCommand);
         Assert.IsType<MoveCommand>(moveCommand);
     }


### PR DESCRIPTION
6. Регистрация зависимости Commands.Move в IoC.
Зарегистрировать зависимость "Commands.Move" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

public class RegisterIoCDependencyMoveCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Примечание: Для того, чтобы создать MoveCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IMovingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IMovingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyMoveCommand зависимость разрешается.

Исполнитель Семикин Николай ФИТ-232