### PR TITLE
Feat/command injectable command

### DIFF
--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,23 +1,26 @@
 ﻿namespace StarWars.Lib;
 
-public interface ICommandInjectable : ICommand
+public interface ICommandInjectable
 {
-    void InjectDependencies(IServiceProvider serviceProvider);
+    void Inject(ICommand command);
+    void Execute();
 }
 
-public class CommandInjectableCommand : ICommandInjectable
+public class CommandInjectableCommand : ICommand, ICommandInjectable
 {
-    private IMoving _obj;
+    private ICommand _injectedCommand;
 
-    public void InjectDependencies(IServiceProvider serviceProvider)
+    public void Inject(ICommand command)
     {
-        _obj = serviceProvider.GetRequiredService<IMoving>();
+        _injectedCommand = command;
     }
 
     public void Execute()
     {
-        if (_obj == null) throw new InvalidOperationException("Dependencies not injected");
-        _obj.Position += _obj.Velocity;
+        if (_injectedCommand == null)
+        {
+            throw new InvalidOperationException("Command not injected");
+        }
+        _injectedCommand.Execute();
     }
 }
-

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,0 +1,23 @@
+﻿namespace StarWars.Lib;
+
+public interface ICommandInjectable : ICommand
+{
+    void InjectDependencies(IServiceProvider serviceProvider);
+}
+
+public class CommandInjectableCommand : ICommandInjectable
+{
+    private IMoving _obj; // Теперь поле не инициализируется в конструкторе
+
+    public void InjectDependencies(IServiceProvider serviceProvider)
+    {
+        _obj = serviceProvider.GetRequiredService<IMoving>();
+    }
+
+    public void Execute()
+    {
+        if (_obj == null) throw new InvalidOperationException("Dependencies not injected");
+        _obj.Position += _obj.Velocity;
+    }
+}
+

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -7,7 +7,7 @@ public interface ICommandInjectable : ICommand
 
 public class CommandInjectableCommand : ICommandInjectable
 {
-    private IMoving _obj; // Теперь поле не инициализируется в конструкторе
+    private IMoving _obj;
 
     public void InjectDependencies(IServiceProvider serviceProvider)
     {

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,42 +1,36 @@
 ﻿using Moq;
+using NUnit.Framework;
 using StarWars.Lib;
+using System;
 
 namespace StarWars.Tests
 {
+    [TestFixture]
     public class CommandInjectableCommandTests
     {
+        [Test]
         public void Execute_InjectedCommand_ExecutesInjectedCommand()
         {
+            // Arrange
             var mockCommand = new Mock<ICommand>();
             var commandInjectableCommand = new CommandInjectableCommand();
             commandInjectableCommand.Inject(mockCommand.Object);
 
+            // Act
             commandInjectableCommand.Execute();
 
-            if (!mockCommand.Verify(c => c.Execute(), Moq.Times.Once))
-            {
-                throw new AssertionException("Injected command was not executed.");
-            }
+            // Assert
+            mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 
+        [Test]
         public void Execute_NoInjectedCommand_ThrowsException()
         {
+            // Arrange
             var commandInjectableCommand = new CommandInjectableCommand();
 
-            try
-            {
-                commandInjectableCommand.Execute();
-                throw new AssertionException("Expected exception was not thrown.");
-            }
-            catch (InvalidOperationException)
-            {
-
-            }
-        }
-
-        private class AssertionException : Exception
-        {
-            public AssertionException(string message) : base(message) { }
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
         }
     }
 }

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,0 +1,44 @@
+﻿using StarWars.Lib;
+using Moq;
+using System;
+
+namespace StarWars.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        public void Execute_InjectedCommand_ExecutesInjectedCommand()
+        {
+            var mockCommand = new Mock<ICommand>();
+            var commandInjectableCommand = new CommandInjectableCommand();
+            commandInjectableCommand.Inject(mockCommand.Object);
+
+            commandInjectableCommand.Execute();
+
+            if (!mockCommand.Verify(c => c.Execute(), Moq.Times.Once))
+            {
+                throw new AssertionException("Injected command was not executed.");
+            }
+        }
+
+        public void Execute_NoInjectedCommand_ThrowsException()
+        {
+            var commandInjectableCommand = new CommandInjectableCommand();
+
+            try
+            {
+                commandInjectableCommand.Execute();
+                throw new AssertionException("Expected exception was not thrown.");
+            }
+            catch (InvalidOperationException)
+            {
+
+            }
+        }
+
+        private class AssertionException : Exception
+        {
+            public AssertionException(string message) : base(message) { }
+        }
+    }
+}
+

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,6 +1,5 @@
-﻿using StarWars.Lib;
-using Moq;
-using System;
+﻿using Moq;
+using StarWars.Lib;
 
 namespace StarWars.Tests
 {


### PR DESCRIPTION
Определить интерфейс ICommandInjectable
public interface ICommandInjectable { void Inject(ICommand command); }

Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.
Критерии приемки:
Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.

Исполнитель Макеев Всеволод ФИТ-232