### PR TITLE
Feat/command injectable command

### DIFF
--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -8,7 +8,9 @@ public interface ICommandInjectable
 
 public class CommandInjectableCommand : ICommand, ICommandInjectable
 {
-    private ICommand _injectedCommand;
+    private ICommand? _injectedCommand;
+
+    public CommandInjectableCommand() { }
 
     public void Inject(ICommand command)
     {

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,23 +1,26 @@
 ﻿namespace StarWars.Lib;
 
-public interface ICommandInjectable : ICommand
+public interface ICommandInjectable
 {
-    void InjectDependencies(IServiceProvider serviceProvider);
+    void Inject(ICommand command);
+    void Execute();
 }
 
-public class CommandInjectableCommand : ICommandInjectable
+public class CommandInjectableCommand : ICommand, ICommandInjectable
 {
-    private IMoving _obj;
+    private ICommand _injectedCommand;
 
-    public void InjectDependencies(IServiceProvider serviceProvider)
+    public void Inject(ICommand command)
     {
-        _obj = serviceProvider.GetRequiredService<IMoving>();
+        _injectedCommand = command;
     }
 
     public void Execute()
     {
-        if (_obj == null) throw new InvalidOperationException("Dependencies not injected");
-        _obj.Position += _obj.Velocity;
+        if (_injectedCommand == null)
+        {
+            throw new InvalidOperationException("Command not injected");
+        }
+        _injectedCommand.Execute();
     }
 }
-

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -17,10 +17,7 @@ public class CommandInjectableCommand : ICommand, ICommandInjectable
 
     public void Execute()
     {
-        if (_injectedCommand == null)
-        {
-            throw new InvalidOperationException("Command not injected");
-        }
-        _injectedCommand.Execute();
+        _injectedCommand?.Execute();
     }
 }
+

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,0 +1,23 @@
+﻿namespace StarWars.Lib;
+
+public interface ICommandInjectable : ICommand
+{
+    void InjectDependencies(IServiceProvider serviceProvider);
+}
+
+public class CommandInjectableCommand : ICommandInjectable
+{
+    private IMoving _obj; // Теперь поле не инициализируется в конструкторе
+
+    public void InjectDependencies(IServiceProvider serviceProvider)
+    {
+        _obj = serviceProvider.GetRequiredService<IMoving>();
+    }
+
+    public void Execute()
+    {
+        if (_obj == null) throw new InvalidOperationException("Dependencies not injected");
+        _obj.Position += _obj.Velocity;
+    }
+}
+

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -7,7 +7,7 @@ public interface ICommandInjectable : ICommand
 
 public class CommandInjectableCommand : ICommandInjectable
 {
-    private IMoving _obj; // Теперь поле не инициализируется в конструкторе
+    private IMoving _obj;
 
     public void InjectDependencies(IServiceProvider serviceProvider)
     {

--- a/StarWars.Lib/StarWars.Lib.csproj
+++ b/StarWars.Lib/StarWars.Lib.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Hwdtech.IoC" Version="1.0.0" />
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 
 </Project>

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
 using StarWars.Lib;
-using System;
 
 namespace StarWars.Tests
 {
@@ -11,27 +10,22 @@ namespace StarWars.Tests
         [Test]
         public void Execute_InjectedCommand_ExecutesInjectedCommand()
         {
-            // Arrange
+
             var mockCommand = new Mock<ICommand>();
             var commandInjectableCommand = new CommandInjectableCommand();
             commandInjectableCommand.Inject(mockCommand.Object);
 
-            // Act
             commandInjectableCommand.Execute();
 
-            // Assert
             mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 
         [Test]
         public void Execute_NoInjectedCommand_ThrowsException()
         {
-            // Arrange
             var commandInjectableCommand = new CommandInjectableCommand();
 
-            // Act & Assert
             Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
         }
     }
 }
-

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,26 +1,23 @@
 ﻿using Moq;
-using NUnit.Framework;
 using StarWars.Lib;
 
 namespace StarWars.Tests
 {
-    [TestFixture]
     public class CommandInjectableCommandTests
     {
-        [Test]
+        [Fact]
         public void Execute_InjectedCommand_ExecutesInjectedCommand()
         {
-
             var mockCommand = new Mock<ICommand>();
             var commandInjectableCommand = new CommandInjectableCommand();
             commandInjectableCommand.Inject(mockCommand.Object);
 
             commandInjectableCommand.Execute();
 
-            mockCommand.Verify(c => c.Execute(), Times.Once);
+            mockCommand.Verify(c => c.Execute(), Moq.Times.Once);
         }
 
-        [Test]
+        [Fact]
         public void Execute_NoInjectedCommand_ThrowsException()
         {
             var commandInjectableCommand = new CommandInjectableCommand();
@@ -29,3 +26,4 @@ namespace StarWars.Tests
         }
     }
 }
+

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -8,20 +8,26 @@ namespace StarWars.Tests
         [Fact]
         public void Execute_InjectedCommand_ExecutesInjectedCommand()
         {
+            // Arrange
             var mockCommand = new Mock<ICommand>();
+            mockCommand.Setup(x => x.Execute()).Verifiable(); // Устанавливаем проверку
             var commandInjectableCommand = new CommandInjectableCommand();
             commandInjectableCommand.Inject(mockCommand.Object);
 
+            // Act
             commandInjectableCommand.Execute();
 
-            mockCommand.Verify(c => c.Execute(), Moq.Times.Once);
+            // Assert
+            mockCommand.Verify(); // Проверяем, что Execute() был вызван
         }
 
         [Fact]
         public void Execute_NoInjectedCommand_ThrowsException()
         {
+            // Arrange
             var commandInjectableCommand = new CommandInjectableCommand();
 
+            // Act & Assert
             Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
         }
     }

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,42 +1,36 @@
 ﻿using Moq;
+using NUnit.Framework;
 using StarWars.Lib;
+using System;
 
 namespace StarWars.Tests
 {
+    [TestFixture]
     public class CommandInjectableCommandTests
     {
+        [Test]
         public void Execute_InjectedCommand_ExecutesInjectedCommand()
         {
+            // Arrange
             var mockCommand = new Mock<ICommand>();
             var commandInjectableCommand = new CommandInjectableCommand();
             commandInjectableCommand.Inject(mockCommand.Object);
 
+            // Act
             commandInjectableCommand.Execute();
 
-            if (!mockCommand.Verify(c => c.Execute(), Moq.Times.Once))
-            {
-                throw new AssertionException("Injected command was not executed.");
-            }
+            // Assert
+            mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 
+        [Test]
         public void Execute_NoInjectedCommand_ThrowsException()
         {
+            // Arrange
             var commandInjectableCommand = new CommandInjectableCommand();
 
-            try
-            {
-                commandInjectableCommand.Execute();
-                throw new AssertionException("Expected exception was not thrown.");
-            }
-            catch (InvalidOperationException)
-            {
-
-            }
-        }
-
-        private class AssertionException : Exception
-        {
-            public AssertionException(string message) : base(message) { }
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
         }
     }
 }

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,0 +1,44 @@
+﻿using StarWars.Lib;
+using Moq;
+using System;
+
+namespace StarWars.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        public void Execute_InjectedCommand_ExecutesInjectedCommand()
+        {
+            var mockCommand = new Mock<ICommand>();
+            var commandInjectableCommand = new CommandInjectableCommand();
+            commandInjectableCommand.Inject(mockCommand.Object);
+
+            commandInjectableCommand.Execute();
+
+            if (!mockCommand.Verify(c => c.Execute(), Moq.Times.Once))
+            {
+                throw new AssertionException("Injected command was not executed.");
+            }
+        }
+
+        public void Execute_NoInjectedCommand_ThrowsException()
+        {
+            var commandInjectableCommand = new CommandInjectableCommand();
+
+            try
+            {
+                commandInjectableCommand.Execute();
+                throw new AssertionException("Expected exception was not thrown.");
+            }
+            catch (InvalidOperationException)
+            {
+
+            }
+        }
+
+        private class AssertionException : Exception
+        {
+            public AssertionException(string message) : base(message) { }
+        }
+    }
+}
+

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,6 +1,5 @@
-﻿using StarWars.Lib;
-using Moq;
-using System;
+﻿using Moq;
+using StarWars.Lib;
 
 namespace StarWars.Tests
 {

--- a/StarWars.Tests/StarWars.Tests.csproj
+++ b/StarWars.Tests/StarWars.Tests.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/star-wars.sln
+++ b/star-wars.sln
@@ -12,9 +12,6 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BCCDB25A-31EC-4EC9-A057-03A0D9B13EBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BCCDB25A-31EC-4EC9-A057-03A0D9B13EBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -24,5 +21,11 @@ Global
 		{7F386899-A71A-4301-92E3-2DC8C0D9F023}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F386899-A71A-4301-92E3-2DC8C0D9F023}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F386899-A71A-4301-92E3-2DC8C0D9F023}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {21D2E3AB-E586-4777-90FE-38D8236CF900}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Определить интерфейс ICommandInjectable
public interface ICommandInjectable { void Inject(ICommand command); }

Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.
Критерии приемки:
Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.

Исполнитель Макеев Всеволод ФИТ-232