### PR TITLE
Feat/CommandInjectableCommand

### DIFF
--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,0 +1,25 @@
+namespace StarWars.Lib;
+
+public interface ICommandInjectable
+{
+    void Inject(ICommand command);
+    void Execute();
+}
+
+public class CommandInjectableCommand : ICommand, ICommandInjectable
+{
+    private ICommand? _injectedCommand;
+
+    public CommandInjectableCommand() { }
+
+    public void Inject(ICommand command)
+    {
+        _injectedCommand = command;
+    }
+
+    public void Execute()
+    {
+        _injectedCommand?.Execute(); 
+    }
+}
+

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -1,4 +1,4 @@
-namespace StarWars.Lib;
+﻿namespace StarWars.Lib;
 
 public interface ICommandInjectable
 {

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -3,7 +3,6 @@
 public interface ICommandInjectable
 {
     void Inject(ICommand command);
-    void Execute();
 }
 public class CommandInjectableCommand : ICommand, ICommandInjectable
 {

--- a/StarWars.Lib/InjectableClass.cs
+++ b/StarWars.Lib/InjectableClass.cs
@@ -5,7 +5,6 @@ public interface ICommandInjectable
     void Inject(ICommand command);
     void Execute();
 }
-
 public class CommandInjectableCommand : ICommand, ICommandInjectable
 {
     private ICommand? _injectedCommand;
@@ -19,7 +18,11 @@ public class CommandInjectableCommand : ICommand, ICommandInjectable
 
     public void Execute()
     {
-        _injectedCommand?.Execute(); 
+        if (_injectedCommand == null)
+        {
+            throw new InvalidOperationException("Command not injected.");
+        }
+
+        _injectedCommand.Execute();
     }
 }
-

--- a/StarWars.Lib/InjectableCommandIoc.cs
+++ b/StarWars.Lib/InjectableCommandIoc.cs
@@ -1,0 +1,14 @@
+﻿using Hwdtech;
+
+namespace StarWars.Lib
+{
+    public class RegisterDependencyCommandInjectableCommand : ICommand
+    {
+        public void Execute()
+        {
+            IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Commands.CommandInjectable",
+            (Func<object, object>)(obj =>
+            new CommandInjectableCommand())).Execute();
+        }
+    }
+}

--- a/StarWars.Tests/InjectableCommandIocTests.cs
+++ b/StarWars.Tests/InjectableCommandIocTests.cs
@@ -1,0 +1,32 @@
+﻿using Hwdtech;
+using Hwdtech.Ioc;
+using StarWars.Lib;
+
+public class RegisterDependencyCommandInjectableCommandTests
+{
+    public RegisterDependencyCommandInjectableCommandTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+    }
+
+    [Fact]
+    public void Execute_RegistersCommandInjectableCommandDependency()
+    {
+        var iocScope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", iocScope).Execute();
+
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        new RegisterDependencyCommandInjectableCommand().Execute();
+
+        var command = IoC.Resolve<StarWars.Lib.ICommand>("Commands.CommandInjectable");
+        Assert.NotNull(command);
+        Assert.IsType<CommandInjectableCommand>(command);
+
+        var injectable = IoC.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+        Assert.NotNull(injectable);
+        Assert.IsType<CommandInjectableCommand>(injectable);
+
+        var concreteCommand = IoC.Resolve<CommandInjectableCommand>("Commands.CommandInjectable");
+        Assert.NotNull(concreteCommand);
+    }
+}

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,0 +1,31 @@
+using Moq;
+using StarWars.Lib;
+
+namespace StarWars.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        [Fact]
+        public void Execute_InjectedCommand_ExecutesInjectedCommand()
+        {
+
+            var mockCommand = new Mock<ICommand>();
+            mockCommand.Setup(x => x.Execute()).Verifiable();
+            var commandInjectableCommand = new CommandInjectableCommand();
+            commandInjectableCommand.Inject(mockCommand.Object);
+
+            commandInjectableCommand.Execute();
+
+            mockCommand.Verify();
+        }
+
+        [Fact]
+        public void Execute_NoInjectedCommand_ThrowsException()
+        {
+            var commandInjectableCommand = new CommandInjectableCommand();
+
+            Assert.Throws<InvalidOperationException>(() => commandInjectableCommand.Execute());
+        }
+    }
+}
+

--- a/StarWars.Tests/InjectableTest.cs
+++ b/StarWars.Tests/InjectableTest.cs
@@ -1,4 +1,4 @@
-using Moq;
+﻿using Moq;
 using StarWars.Lib;
 
 namespace StarWars.Tests


### PR DESCRIPTION
16. Определить интерфейс ICommandInjectable
public interface ICommandInjectable { void Inject(ICommand command); }

17. Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.
Критерии приемки:
Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.

18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.
Указание: Для регистрации зависимости определить команду RegisterMacroCommand:
public class RegisterDependencyCommandInjectableCommand : ICommand { public void Execute() { // код, регистрирующий зависимость } }
Copy
Критерии приемки:
Реализован тест, который проверяет, что следующий код работает без выброса исключений:
Ioc.Resolve<ICommand>("Commands.CommadInjectable"); Ioc.Resolve<ICommandInjectable>("Commands.CommadInjectable"); Ioc.Resolve<CommandInjectableCommand>("Commands.CommadInjectable");

Выполнил Макеев Всеволод ФИТ-232